### PR TITLE
mfxsink: Fixed wayland weston fullscreen issue

### DIFF
--- a/gst/mfx/gstmfxsink.c
+++ b/gst/mfx/gstmfxsink.c
@@ -775,15 +775,21 @@ gst_mfxsink_ensure_render_rect (GstMfxSink * sink, guint width, guint height)
   GST_DEBUG ("video size %dx%d, calculated ratio %d/%d",
       sink->video_width, sink->video_height, num, den);
 
-  display_rect->width = gst_util_uint64_scale_int (height, num, den);
-  if (display_rect->width <= width) {
-    GST_DEBUG ("keeping window height");
-    display_rect->height = height;
-  } else {
-    GST_DEBUG ("keeping window width");
+  if (sink->fullscreen) {
     display_rect->width = width;
-    display_rect->height = gst_util_uint64_scale_int (width, den, num);
+    display_rect->height= height;
+  } else {
+    display_rect->width = gst_util_uint64_scale_int (height, num, den);
+    if (display_rect->width <= width) {
+      GST_DEBUG ("keeping window height");
+      display_rect->height = height;
+    } else {
+      GST_DEBUG ("keeping window width");
+      display_rect->width = width;
+      display_rect->height = gst_util_uint64_scale_int (width, den, num);
+    }
   }
+
   GST_DEBUG ("scaling video to %ux%u", display_rect->width,
       display_rect->height);
 


### PR DESCRIPTION
This issue is introduced by commit id:
bdd61edceddd91ebc8a63f401c235b2520f93d25

When detected the sink is displaying in fullcreen, we don't
calculate ratio for display_rect->width and display_rect->height.
Both of display_rect width and height will set based on pass
in width and height.

Signed-off-by: Lim Siew Hoon <siew.hoon.lim@intel.com>