### PR TITLE
mfxsurface: Added missing GST_VIDEO_FORMAT_BGRx support by gst-mfx.

### DIFF
--- a/gst-libs/mfx/gstmfxsurface.c
+++ b/gst-libs/mfx/gstmfxsurface.c
@@ -180,6 +180,7 @@ gst_mfx_surface_derive_mfx_frame_info(GstMfxSurface * surface,
       frame_info->ChromaFormat = MFX_CHROMAFORMAT_YUV422;
       break;
     case GST_VIDEO_FORMAT_BGRA:
+    case GST_VIDEO_FORMAT_BGRx:
       frame_info->ChromaFormat = MFX_CHROMAFORMAT_YUV444;
       break;
     default:


### PR DESCRIPTION
This issue is introduced by commit id :
6a303ac0d602e6dc5fe2051a172a141d2cae80d3. This commit id was remove the
hardcore frame_info->ChromaFormat value which is only hardcode to
MFX_CHROMAFORMAT_YUV420. It didn't check based on color format to assign
the correct chroma format.

Unfortunely, we missed out the GST_VIDEO_FORMAT_BGRx color format that we
need to support. This code fixed will be added in missing GST_VIDEO_FORMAT_BGRx
that we missed out.

Signed-off-by: Lim Siew Hoon <siew.hoon.lim@intel.com>