### PR TITLE
Setting MPEG2 Encode default as NO

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,7 +4,7 @@ option('MFX_VP9_DECODER', type : 'boolean', value : false)
 option('MFX_ENCODER', type : 'boolean', value : true)
 option('MFX_H264_ENCODER', type : 'boolean', value : true)
 option('MFX_H265_ENCODER', type : 'boolean', value : false)
-option('MFX_MPEG2_ENCODER', type : 'boolean', value : true)
+option('MFX_MPEG2_ENCODER', type : 'boolean', value : false)
 option('MFX_JPEG_ENCODER', type : 'boolean', value : true)
 
 option('MFX_VPP', type : 'boolean', value : true)


### PR DESCRIPTION
On newer hardware, MPEG2 encode HW acceleration is no longer supported.
Making MPEG2 encode default build option to false and need to be explitly turned ON.

Signed-off-by: Raynald Lim <raynald.lim@intel.com>