### PR TITLE
mfxjpegdec: fix decode issues with JPEG444 formats

### DIFF
--- a/gst-libs/mfx/gstmfxdecoder.c
+++ b/gst-libs/mfx/gstmfxdecoder.c
@@ -271,6 +271,11 @@ gst_mfx_decoder_reconfigure_params (GstMfxDecoder * decoder)
     frame_info->Height = GST_ROUND_UP_32 (decoder->info.height);
   }
 
+  if (decoder->profile.codec == MFX_CODEC_JPEG) {
+    frame_info->FourCC = MFX_FOURCC_RGB4;
+    frame_info->ChromaFormat = MFX_CHROMAFORMAT_YUV444;
+  }
+
   frame_info->FrameRateExtN = decoder->info.fps_n;
   frame_info->FrameRateExtD = decoder->info.fps_d;
 


### PR DESCRIPTION
Fixes intel/gstreamer-media-SDK#110.