### PR TITLE
fixed third party plugin integration issue with gst-msdk and standized all the drm header only locate based on user space libdrm header.

### DIFF
--- a/gst-libs/mfx/gstmfxsurface_vaapi.c
+++ b/gst-libs/mfx/gstmfxsurface_vaapi.c
@@ -26,7 +26,7 @@
 
 #include <glib.h>
 #include <xf86drm.h>
-#include <i915_drm.h>
+#include <libdrm/i915_drm.h>
 #include <va/va_drmcommon.h>
 #include <fcntl.h>
 

--- a/gst-libs/mfx/sysdeps.h
+++ b/gst-libs/mfx/sysdeps.h
@@ -28,7 +28,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <drm.h>
+#include <libdrm/drm.h>
 
 #include <gst/gst.h>
 #include <mfxvideo.h>

--- a/gst/mfx/gstmfxsink.c
+++ b/gst/mfx/gstmfxsink.c
@@ -367,10 +367,18 @@ configure_notify_event_pending (GstMfxSink * sink, Window window,
 static gboolean
 gst_mfxsink_x11_create_window (GstMfxSink * sink, guint width, guint height)
 {
-  g_return_val_if_fail (sink->window == NULL, FALSE);
-  sink->window = gst_mfx_window_x11_new (sink->display, width, height);
+  XID xid = 0;
+
+  if (sink->foreign_window == TRUE && sink->app_window_handle != 0) {
+    xid = sink->app_window_handle;
+    sink->window = gst_mfx_window_x11_new_with_xid (sink->display, xid);
+  } else {
+    sink->window = gst_mfx_window_x11_new (sink->display, width, height);
+  }
+
   if (!sink->window)
     return FALSE;
+
   return TRUE;
 }
 
@@ -493,6 +501,7 @@ gst_mfxsink_video_overlay_set_window_handle (GstVideoOverlay * overlay,
   GstMfxSink *const sink = GST_MFXSINK (overlay);
 
   sink->foreign_window = TRUE;
+  sink->app_window_handle = window;
   if (sink->backend && sink->backend->create_window_from_handle)
     sink->backend->create_window_from_handle (sink, window);
 }
@@ -1097,6 +1106,9 @@ gst_mfxsink_destroy (GstMfxSink * sink)
   gst_mfx_display_replace (&sink->display, NULL);
 
   gst_caps_replace (&sink->caps, NULL);
+
+  sink->app_window_handle = 0;
+
   g_free (sink->display_name);
 }
 
@@ -1312,5 +1324,6 @@ gst_mfxsink_init (GstMfxSink * sink)
   sink->keep_aspect = TRUE;
   sink->no_frame_drop = FALSE;
   sink->full_color_range = FALSE;
+  sink->app_window_handle = 0;
   gst_video_info_init (&sink->video_info);
 }

--- a/gst/mfx/gstmfxsink.h
+++ b/gst/mfx/gstmfxsink.h
@@ -111,6 +111,8 @@ struct _GstMfxSink
   guint                      keep_aspect : 1;
   guint                      no_frame_drop : 1;
   guint                      full_color_range : 1;
+
+  guintptr                   app_window_handle;
 };
 
 struct _GstMfxSinkClass


### PR DESCRIPTION
1. Keep the 3rd party plugin window handle using for sink->window creation. 
2. To standardized all the drm header, only locate based on user space libdrm header.

