### PR TITLE
Fix

### DIFF
--- a/gst-libs/mfx/wayland/gstmfxwindow_wayland.c
+++ b/gst-libs/mfx/wayland/gstmfxwindow_wayland.c
@@ -252,7 +252,7 @@ gst_mfx_window_wayland_render (GstMfxWindow * window,
       || (dst_rect->width != src_rect->width)) {
     if (priv->viewport) {
       wl_viewport_set_destination (priv->viewport,
-          window->width, window->height);
+          dst_rect->width, dst_rect->height);
     }
   }
 

--- a/gst/mfx/gstmfxdec.c
+++ b/gst/mfx/gstmfxdec.c
@@ -574,13 +574,15 @@ gst_mfxdec_handle_frame (GstVideoDecoder *vdec, GstVideoCodecFrame * frame)
 error_decode:
   {
     GST_ERROR_OBJECT (mfxdec, "MFX decode error %d", sts);
-    gst_video_decoder_drop_frame (vdec, frame);
+    if (mfxdec->prev_surf)
+      gst_video_decoder_drop_frame (vdec, frame);
     return GST_FLOW_NOT_SUPPORTED;
   }
 not_negotiated:
   {
     GST_ERROR_OBJECT (mfxdec, "not negotiated");
-    gst_video_decoder_drop_frame (vdec, frame);
+    if (mfxdec->prev_surf)
+      gst_video_decoder_drop_frame (vdec, frame);
     return GST_FLOW_NOT_NEGOTIATED;
   }
 }

--- a/gst/mfx/gstmfxsink.c
+++ b/gst/mfx/gstmfxsink.c
@@ -785,7 +785,10 @@ gst_mfxsink_ensure_render_rect (GstMfxSink * sink, guint width, guint height)
       sink->video_width, sink->video_height, num, den);
 
   if (sink->fullscreen) {
-    display_rect->width = width;
+    if (sink->video_width > sink->video_height)
+      display_rect->width = width;
+    else
+      display_rect->width = gst_util_uint64_scale_int (height, num, den);
     display_rect->height= height;
   } else {
     display_rect->width = gst_util_uint64_scale_int (height, num, den);


### PR DESCRIPTION
This pull request fixed two issue: 


First issue for https://hsdes.intel.com/appstore/article/#/1506128169
gst-msdk plugin rotation video outstretching on wayland
command: gst-launch-1.0 filesrc location= ! h264parse ! mfxh264dec ! mfxvpp rotation=90 ! mfxsink fullscreen=true
Code fixed: 4b65a2dd32006bb2e29e9cbf0240494fd2675095

Second issue for https://hsdes.intel.com/appstore/article/#/1806307512 with gst-command pipeline below:
command: G_SLICE=always-malloc MALLOC_PERTURB_=3 gst-launch-1.0 filesrc location=data.h264 !  h264parse ! mfxdecode live-mode=true ! 'video/x-raw(memory:MFXSurface),format=BGRA' ! fakesink sync=false

command: G_SLICE=always-malloc MALLOC_PERTURB_=3 gst-launch-1.0 filesrc location=data.h264 !  h264parse ! mfxdecode live-mode=true ! 'video/x-raw(memory:MFXSurface),format=BGRA' ! mfxsink sync=false

Code fixed :  
i) 149fcfed57fe258588ae8c46233074ab688b2575
ii) 4b65a2dd32006bb2e29e9cbf0240494fd2675095