### PR TITLE
Fixed  frame info corruption issue and Fatal IO error 9 issue.

### DIFF
--- a/gst-libs/mfx/gstmfxdecoder.c
+++ b/gst-libs/mfx/gstmfxdecoder.c
@@ -807,6 +807,9 @@ error:
 static gboolean
 gst_mfx_decoder_reinit (GstMfxDecoder * decoder, mfxFrameInfo * info)
 {
+  mfxFrameInfo tmp_frameinfo;
+  if (info)
+    tmp_frameinfo = *info;
   /*
    * Only CSC and deinterlacing didn't involve, it will be re-use back
    * VASurfaces when restart back MSDK decoder.
@@ -818,7 +821,7 @@ gst_mfx_decoder_reinit (GstMfxDecoder * decoder, mfxFrameInfo * info)
   close_decoder(decoder);
 
   if (info)
-    decoder->params.mfx.FrameInfo = *info;
+    decoder->params.mfx.FrameInfo = tmp_frameinfo;
 
   /* Only initialize filter when need to use CSC or deinterlacing. */
   if ((decoder->enable_csc || decoder->enable_deinterlace) && !decoder->filter)


### PR DESCRIPTION
First issue:
Fixed frame info corruption issue during decoder reinitialized with with G_SLICE=always-malloc MALLOC_PERTURB_=3 environment variable turn on.

Second issue:
Replace the xcb_dri3_pixmap_from_buffer to xcb_dri3_pixmap_from_buffer_checked.
To ensure there are no error happen xcb_dri3_pixmap_from_buffer causing the Fatal IO error 9.