### PR TITLE
mfxsurface_vaapi: Refactor on handle allocation PRIME buffer in NV12 …

### DIFF
--- a/gst-libs/mfx/gstmfxdisplay.h
+++ b/gst-libs/mfx/gstmfxdisplay.h
@@ -25,6 +25,7 @@
 
 #include <va/va.h>
 #include <gst/gst.h>
+#include <libdrm/intel_bufmgr.h>
 #include "gstmfxtypes.h"
 
 G_BEGIN_DECLS
@@ -129,6 +130,9 @@ gst_mfx_display_use_opengl (GstMfxDisplay * display);
 
 int
 get_display_fd (GstMfxDisplay * display);
+
+drm_intel_bufmgr *
+get_display_bufmgr (GstMfxDisplay * display);
 
 G_END_DECLS
 

--- a/gst-libs/mfx/gstmfxdisplay_priv.h
+++ b/gst-libs/mfx/gstmfxdisplay_priv.h
@@ -30,6 +30,10 @@
 
 G_BEGIN_DECLS
 
+#ifndef BATCH_SIZE
+#define BATCH_SIZE 0x80000
+#endif
+
 #define GST_MFX_DISPLAY_CAST(display) \
   ((GstMfxDisplay *) (display))
 
@@ -100,6 +104,7 @@ struct _GstMfxDisplayPrivate
   guint par_d;
   gchar *vendor_string;
   gboolean is_opengl;
+  drm_intel_bufmgr *bufmgr;
 };
 
 /**

--- a/gst-libs/mfx/gstmfxprimebufferproxy.c
+++ b/gst-libs/mfx/gstmfxprimebufferproxy.c
@@ -197,7 +197,7 @@ gst_mfx_prime_buffer_proxy_replace (GstMfxPrimeBufferProxy ** old_proxy_ptr,
 guintptr
 gst_mfx_prime_buffer_proxy_get_handle (GstMfxPrimeBufferProxy * proxy)
 {
-  g_return_val_if_fail (proxy != NULL, 0);
+  g_return_val_if_fail (proxy != NULL, -1);
 
   return proxy->fd;
 }

--- a/gst-libs/mfx/gstmfxsurface.c
+++ b/gst-libs/mfx/gstmfxsurface.c
@@ -307,14 +307,14 @@ GstMfxSurface *
 gst_mfx_surface_new (const GstVideoInfo * info)
 {
   return gst_mfx_surface_new_internal(gst_mfx_surface_class(), NULL, info, NULL,
-            FALSE, -1);
+            FALSE);
 }
 
 GstMfxSurface *
 gst_mfx_surface_new_from_task (GstMfxTask * task)
 {
   return gst_mfx_surface_new_internal(gst_mfx_surface_class(), NULL, NULL, task,
-            FALSE, -1);
+            FALSE);
 }
 
 GstMfxSurface *
@@ -328,7 +328,7 @@ gst_mfx_surface_new_from_pool(GstMfxSurfacePool * pool)
 GstMfxSurface *
 gst_mfx_surface_new_internal(const GstMfxSurfaceClass * klass,
     GstMfxDisplay * display, const GstVideoInfo * info, GstMfxTask * task,
-    gboolean is_linear, gint dri_fd)
+    gboolean is_linear)
 {
   GstMfxSurface *surface;
 
@@ -339,7 +339,6 @@ gst_mfx_surface_new_internal(const GstMfxSurfaceClass * klass,
 
   surface->gem_bo_handle = -1;
   surface->is_gem_linear = is_linear;
-  surface->drm_fd = dri_fd;
 
   surface->surface_id = GST_MFX_ID_INVALID;
   if (display)
@@ -371,6 +370,8 @@ gst_mfx_surface_copy(GstMfxSurface * surface)
   copy->width = surface->width;
   copy->height = surface->height;
   copy->crop_rect = surface->crop_rect;
+  copy->gem_bo_handle = -1;
+  copy->is_gem_linear = FALSE;
 
   return copy;
 }

--- a/gst-libs/mfx/gstmfxsurface_priv.h
+++ b/gst-libs/mfx/gstmfxsurface_priv.h
@@ -64,7 +64,9 @@ struct _GstMfxSurface
 
   gint gem_bo_handle;
   gboolean is_gem_linear;
-  gint drm_fd;
+
+  drm_intel_bufmgr *bufmgr;
+  drm_intel_bo *bo;
 };
 
 struct _GstMfxSurfaceClass
@@ -82,7 +84,7 @@ struct _GstMfxSurfaceClass
 GstMfxSurface *
 gst_mfx_surface_new_internal(const GstMfxSurfaceClass * klass,
     GstMfxDisplay * display, const GstVideoInfo * info, GstMfxTask * task,
-    gboolean is_linear, gint dri_fd);
+    gboolean is_linear);
 
 #define gst_mfx_surface_ref_internal(surface) \
   ((gpointer)gst_mfx_mini_object_ref(GST_MFX_MINI_OBJECT(surface)))

--- a/gst-libs/mfx/wayland/gstmfxdisplay_wayland_priv.h
+++ b/gst-libs/mfx/wayland/gstmfxdisplay_wayland_priv.h
@@ -47,10 +47,6 @@ G_BEGIN_DECLS
 #define GST_MFX_DISPLAY_WAYLAND_GET_PRIVATE(display) \
   (&GST_MFX_DISPLAY_WAYLAND_CAST(display)->priv)
 
-#ifndef BATCH_SIZE
-#define BATCH_SIZE 0x80000
-#endif
-
 typedef struct _GstMfxDisplayWaylandPrivate   GstMfxDisplayWaylandPrivate;
 typedef struct _GstMfxDisplayWaylandClass     GstMfxDisplayWaylandClass;
 


### PR DESCRIPTION
…linear dmabuf sharing.

gem object alloc and free called thru using the libdrm API function to handle
instead of calling thru DRM_IOCTL to do it.

Signed-off-by: Lim Siew Hoon <siew.hoon.lim@intel.com>