### PR TITLE
mfx wayland display: Add output_handle_done listener function

### DIFF
--- a/gst-libs/mfx/wayland/gstmfxdisplay_wayland.c
+++ b/gst-libs/mfx/wayland/gstmfxdisplay_wayland.c
@@ -85,9 +85,16 @@ output_handle_mode (void *data, struct wl_output *wl_output,
   }
 }
 
+static void
+output_handle_done (void *data, struct wl_output *wl_output)
+{
+  /* NOT IMPLEMENTED */
+}
+
 static const struct wl_output_listener output_listener = {
   output_handle_geometry,
   output_handle_mode,
+  output_handle_done,
 };
 
 /* DRM listeners for wl_drm interface */


### PR DESCRIPTION
Add output_handle_done listener function to resolve NULL pointer call
problem. Without this patch, below error is shown.
listener function for opcode 1463118720 of is NULL
Aborted (core dumped)